### PR TITLE
Use the SLF4J BOM to Manage SLF4J Versions

### DIFF
--- a/dropwizard-dependencies/pom.xml
+++ b/dropwizard-dependencies/pom.xml
@@ -352,23 +352,10 @@
             <!-- Logging dependencies -->
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
+                <artifactId>slf4j-bom</artifactId>
                 <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jul-to-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>jcl-over-slf4j</artifactId>
-                <version>${slf4j.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
                 <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
###### Problem:
Sometimes, downstream projects use slf4j dependencies that are not managed by dropwizard. (ie, slf4j-simple for test scope) Projects have to then keep their managed version of slf4j in sync with upstream. 

###### Solution:
Slf4j now has a bom. Use it!

Since the bom only exists for version 2.0.x I don't think this can be back ported to the DW 2.1.x branch.

###### Result:
Simplified dependency management for dropwizard projects.


